### PR TITLE
Fix on hardcoded variables and dependency inconsistencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ git clone https://github.com/hku-systems/kakute.git
 
 ```
 
-Setup the correct phosphor directory in core/pom.xml
+Setup the correct phosphor directory in core/pom.xml (change $DIRECTORY_TO_PHOSPHOR to where the PHOSPHOR locates, the default is $HOME)
 ```
 <dependency>
   <groupId>edu.columbia.cs</groupId>
@@ -47,7 +47,7 @@ cd kakute
 build/mvn -DskipTests clean package
 ```
 
-Modify **dft.conf** according your configuration of phosphor.
+Modify **dft.conf** according your configuration of phosphor. (change $DIRECTORY_TO_PHOSPHOR to where the PHOSPHOR locates, the default is $HOME)
 ```
 dft-host = 127.0.0.1 // driver host ip
 dft-port = 8787 // driver host port

--- a/core/src/main/scala/edu/hku/cs/dft/README.md
+++ b/core/src/main/scala/edu/hku/cs/dft/README.md
@@ -61,8 +61,8 @@
    # dft.conf
    dft-host = 127.0.0.1
    dft-port = 8787
-   dft-phosphor-java = /home/jianyu/phosphor/Phosphor/target/jre-inst-int
-   dft-phosphor-jar = /home/jianyu/phosphor/Phosphor-0.0.3-SNAPSHOT.jar
+   dft-phosphor-java = $HOME/phosphor/Phosphor/target/jre-inst-int
+   dft-phosphor-jar = $HOME/phosphor/Phosphor-0.0.3-SNAPSHOT.jar
    dft-phosphor-cache = dft-cache
    dft-graph-dump-path = graph.dump
    ```

--- a/core/src/main/scala/edu/hku/cs/dft/README.md
+++ b/core/src/main/scala/edu/hku/cs/dft/README.md
@@ -55,14 +55,14 @@
 
 ### Run the project
 
-1. Set up the configuration file (dft.conf), a sample is
+1. Set up the configuration file (dft.conf), a sample is(change the $DIRECTORY_TO_PHOSPHOR to where the PHOSPHOR locates, the default is $HOME)
 
    ```ini
    # dft.conf
    dft-host = 127.0.0.1
    dft-port = 8787
-   dft-phosphor-java = $HOME/phosphor/Phosphor/target/jre-inst-int
-   dft-phosphor-jar = $HOME/phosphor/Phosphor-0.0.3-SNAPSHOT.jar
+   dft-phosphor-java = $DIRECTORY_TO_PHOSPHOR/Phosphor/target/jre-inst-int
+   dft-phosphor-jar = $DIRECTORY_TO_PHOSPHOR/phosphor/Phosphor-0.0.3-SNAPSHOT.jar
    dft-phosphor-cache = dft-cache
    dft-graph-dump-path = graph.dump
    ```

--- a/dev/check-license
+++ b/dev/check-license
@@ -20,7 +20,7 @@
 
 acquire_rat_jar () {
 
-  URL="http://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+  URL="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
 
   JAR="$rat_jar"
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -169,7 +169,7 @@ def determine_java_version(java_exe):
     # find raw version string, eg 'java version "1.8.0_25"'
     raw_version_str = next(x for x in raw_output_lines if " version " in x)
 
-    match = re.search('(\d+)\.(\d+)\.(\d+)', raw_version_str)
+    match = re.search(r'(\d+)\.(\d+)\.(\d+)', raw_version_str)
 
     major = int(match.group(1))
     minor = int(match.group(2))

--- a/dft.conf
+++ b/dft.conf
@@ -1,8 +1,8 @@
 dft-host = 127.0.0.1
 dft-port = 8787
-dft-phosphor-java = /home/jianyu/phosphor/Phosphor/target/
-dft-phosphor-jar = /home/jianyu/phosphor/Phosphor/target/Phosphor-0.0.3-SNAPSHOT.jar
-dft-phosphor-cache = /home/jianyu/dft-cache
+dft-phosphor-java = $HOME/phosphor/Phosphor/target/
+dft-phosphor-jar = $HOME/phosphor/Phosphor/target/Phosphor-0.0.3-SNAPSHOT.jar
+dft-phosphor-cache = $HOME/dft-cache
 graph_dump_path = graph.dump
 dft-tracking = rule
 dft-input-taint = false

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <artifactId>phosphor</artifactId>
         <version>0.0.3</version>
         <scope>system</scope>
-        <systemPath>/home/jianyu/phosphor/Phosphor/target/Phosphor-0.0.3-SNAPSHOT.jar</systemPath>
+        <systemPath>$HOME/phosphor/Phosphor/target/Phosphor-0.0.3-SNAPSHOT.jar</systemPath>
       </dependency>
       <dependency>
         <groupId>com.twitter</groupId>


### PR DESCRIPTION
Update URLs and file paths
1. Change Maven repository URL from HTTP to HTTPS
2. Add raw string prefix to regex pattern in version parsing
3. Replace hardcoded home directory paths with $HOME variable